### PR TITLE
Fix Android build issue with mkostemp call

### DIFF
--- a/include/diy/io/utils.hpp
+++ b/include/diy/io/utils.hpp
@@ -115,7 +115,7 @@ namespace utils
     s_template[filename.size()] = 0;
 
     int handle = -1;
-#if defined(__MACH__)
+#if defined(__MACH__) || defined(__ANDROID_API__)
     // TODO: figure out how to open with O_SYNC
     handle = ::mkstemp(s_template.get());
 #else


### PR DESCRIPTION
Replace mkostemp by mkstemp as done for MACH.

Side note: needed for fixing VTK builds for some Android API levels.